### PR TITLE
Remove crashedNodes and make primary promotion non-deterministic

### DIFF
--- a/elasticsearch.toolbox/elasticsearch___model.launch
+++ b/elasticsearch.toolbox/elasticsearch___model.launch
@@ -7,6 +7,7 @@
 <booleanAttribute key="dfidMode" value="false"/>
 <intAttribute key="distributedFPSetCount" value="0"/>
 <stringAttribute key="distributedNetworkInterface" value="192.168.178.34"/>
+<intAttribute key="distributedNodesCount" value="1"/>
 <stringAttribute key="distributedTLC" value="off"/>
 <stringAttribute key="distributedTLCVMArgs" value=""/>
 <intAttribute key="fpBits" value="0"/>
@@ -18,7 +19,7 @@
 <stringAttribute key="modelBehaviorNext" value="Next"/>
 <stringAttribute key="modelBehaviorSpec" value="Spec"/>
 <intAttribute key="modelBehaviorSpecType" value="2"/>
-<stringAttribute key="modelBehaviorVars" value="nextClientValue, clusterStateOnMaster, globalCheckPoint, tlog, messages, clientResponses, crashedNodes, currentTerm, clusterStateOnNode, nextRequestId, localCheckPoint"/>
+<stringAttribute key="modelBehaviorVars" value="nextClientValue, clusterStateOnMaster, globalCheckPoint, tlog, messages, clientResponses, currentTerm, clusterStateOnNode, nextRequestId, localCheckPoint"/>
 <stringAttribute key="modelComments" value=""/>
 <booleanAttribute key="modelCorrectnessCheckDeadlock" value="false"/>
 <listAttribute key="modelCorrectnessInvariants">
@@ -46,7 +47,7 @@
 <listEntry value="Replication;;Replication;1;0"/>
 <listEntry value="TrimTranslog;;TrimTranslog;1;0"/>
 </listAttribute>
-<stringAttribute key="modelParameterContraint" value="nextClientValue &lt;= 3"/>
+<stringAttribute key="modelParameterContraint" value="StateConstraint"/>
 <listAttribute key="modelParameterDefinitions"/>
 <stringAttribute key="modelParameterModelValues" value="{}"/>
 <stringAttribute key="modelParameterNewDefinitions" value=""/>


### PR DESCRIPTION
Explicitly keeping track of the crashed nodes blows up the state space that is explored by the model checker. Instead of explicitly having nodes marked as crashed, the other transition relations allow such nodes to (implicitly) just not react to any messages.

This commit also changes primary promotion to non-deterministically choose a replica (using the "exists" quantifier instead of the "CHOOSE" operator).

With the updated state constraint, model checking takes 3 hours on my machine.