### PR TITLE
Make sending of master state to nodes be asynchronous

### DIFF
--- a/elasticsearch.toolbox/elasticsearch___model.launch
+++ b/elasticsearch.toolbox/elasticsearch___model.launch
@@ -46,6 +46,7 @@
 <listEntry value="DocumentIds;;{id1, id2};1;1"/>
 <listEntry value="Replication;;Replication;1;0"/>
 <listEntry value="TrimTranslog;;TrimTranslog;1;0"/>
+<listEntry value="SendMasterState;;SendMasterState;1;0"/>
 </listAttribute>
 <stringAttribute key="modelParameterContraint" value="StateConstraint"/>
 <listAttribute key="modelParameterDefinitions"/>


### PR DESCRIPTION
`ApplyClusterStateFromMaster` seems to copy the state from the master to the target node synchronously, guaranteeing that the target always receives the current state. It strikes me it might be more realistic to represent this as an asynchronous message, allowing for the received state to be somewhat stale, which is what I'm trying to do with this change.

This leads to a violation of the `GlobalCheckPointBelowLocalCheckPoints` invariant.

(It's quite likely there's a good reason that how it was originally modelled is correct - I'm just exploring the spec a bit)