### PR TITLE
Stronger state constraint?

### DIFF
--- a/elasticsearch.tla
+++ b/elasticsearch.tla
@@ -839,6 +839,9 @@ WellFormedRoutingTable(routingTable) ==
   /\ (   Cardinality(Primaries(routingTable)) = 0
       => Cardinality(Assigned (routingTable)) = 0)
 
-StateConstraint == nextClientValue <= 3 /\ Cardinality(messages) <= 5
+StateConstraint ==
+  /\ nextClientValue <= 3
+  /\ Cardinality(messages) <= 5
+  /\ 0 < Cardinality(Assigned (clusterStateOnMaster.routingTable))
 
 =============================================================================

--- a/elasticsearch.tla
+++ b/elasticsearch.tla
@@ -833,8 +833,11 @@ LocalCheckPointMatchesMaxConfirmedSeq ==
     => /\ localCheckPoint[n][n] = MaxConfirmedSeq(tlog[n])
        /\ MaxSeq(tlog[n]) = MaxConfirmedSeq(tlog[n])
 
-\* routing table is well-formed (has at most one primary)
-WellFormedRoutingTable(routingTable) == Cardinality(Primaries(routingTable)) <= 1
+\* routing table is well-formed (has at most one primary, and has no replicas if no primaries)
+WellFormedRoutingTable(routingTable) ==
+  /\ Cardinality(Primaries(routingTable)) <= 1
+  /\ (   Cardinality(Primaries(routingTable)) = 0
+      => Cardinality(Assigned (routingTable)) = 0)
 
 StateConstraint == nextClientValue <= 3 /\ Cardinality(messages) <= 5
 


### PR DESCRIPTION
Since there's currently no provision for repairing failed nodes, is this a reasonable change to make to the `StateConstraint`? It seems to reduce the state space quite a bit.

Also strengthened the `WellFormedRoutingTable` invariant to assert that there's never a `Replica` without a `Primary`.